### PR TITLE
A new admin setting to optionally notify members by email upon every …

### DIFF
--- a/core/config.defaults.php
+++ b/core/config.defaults.php
@@ -132,6 +132,7 @@ $config["esoTalk.minPasswordLength"] = 6;
 $config["esoTalk.userOnlineExpire"] = 300; // Number of seconds a user's 'last seen time' is before the user 'goes offline'.
 $config["esoTalk.sitemapCacheTime"] = 3600; // Keep sitemaps for at least 1 hour.
 $config["esoTalk.updateCheckInterval"] = 86400; // How often esoTalk should ping esotalk.org to check for a new version. Default = 1 day. Set to 0 to disable update checking.
+$config["esoTalk.emailNotifyEveryReply"] = false;
 
 // Default user preferences.
 $config["esoTalk.preferences.email.privateAdd"] = true;

--- a/core/controllers/admin/ETSettingsAdminController.class.php
+++ b/core/controllers/admin/ETSettingsAdminController.class.php
@@ -39,6 +39,7 @@ public function action_index()
 	$form->setValue("memberListVisibleToGuests", C("esoTalk.members.visibleToGuests"));
 	$form->setValue("registrationOpen", C("esoTalk.registration.open"));
 	$form->setValue("requireConfirmation", C("esoTalk.registration.requireConfirmation"));
+	$form->setValue("emailNotifyEveryReply", C("esoTalk.emailNotifyEveryReply"));
 
 	$c = C("esoTalk.conversation.editPostTimeLimit");
 	if ($c === -1) $form->setValue("editPostMode", "forever");
@@ -70,6 +71,7 @@ public function action_index()
 			"esoTalk.members.visibleToGuests" => $form->getValue("forumVisibleToGuests") and $form->getValue("memberListVisibleToGuests"),
 			"esoTalk.registration.open" => $form->getValue("registrationOpen"),
 			"esoTalk.registration.requireConfirmation" => in_array($v = $form->getValue("requireConfirmation"), array(false, "email", "approval")) ? $v : false,
+			"esoTalk.emailNotifyEveryReply" => $form->getValue("emailNotifyEveryReply"),
 		);
 
 		switch ($form->getValue("editPostMode")) {

--- a/core/models/ETActivityModel.class.php
+++ b/core/models/ETActivityModel.class.php
@@ -128,6 +128,13 @@ public function create($type, $member, $fromMember = null, $data = null, $emailD
 	$activity["fromMemberName"] = $fromMember ? $fromMember["username"] : null;
 	$activity["activityId"] = $activityId;
 
+	// Hack: there is no user preference "email.repost" - if the user has email.post == true, they automatically get repost as well
+	// Treat "repost" activity type as a "post" activity type for the purposes of the email section below
+	if ($type == "repost")
+	{
+		$type = "post";
+	}
+
 	// If this activity type has an email projection, the member wants to receive an email notification
 	// for this type, and we haven't set sent them one in a previous call of this method, then let's send one!
 	if (!empty($projections[self::PROJECTION_EMAIL]) and !empty($member["preferences"]["email.$type"]) and !in_array($member["memberId"], $this->membersUsed)) {
@@ -590,4 +597,9 @@ ETActivityModel::addType("updateAvailable", array(
 // Notification for when a new user signs up and needs approval.
 ETActivityModel::addType("unapproved", array(
 	"notification" => array("ETActivityModel", "unapprovedNotification")
+));
+
+// Notification for when a member has two or more unread posts in a starred conversation (like "post" but only sends an email)
+ETActivityModel::addType("repost", array(
+        "email" => array("ETActivityModel", "postEmail")
 ));

--- a/core/views/admin/settings.php
+++ b/core/views/admin/settings.php
@@ -97,6 +97,18 @@ $(function() {
 
 <li class='sep'></li>
 
+<li>
+<label><?php echo T("Global notifications"); ?></label>
+<div class='subText'><?php echo T("Members who have asked to be emailed when someone posts in a thread they have followed:"); ?></div>
+<div class='checkboxGroup'>
+<label class='radio'><?php echo $form->radio("emailNotifyEveryReply", 0); ?> <?php echo T("Are emailed on the first unread reply only"); ?></label>
+<label class='radio'><?php echo $form->radio("emailNotifyEveryReply", 1); ?> <?php echo T("Are emailed on every reply"); ?></label>
+</div>
+</li>
+
+<li class='sep'></li>
+
+
 <li><?php echo $form->saveButton(); ?></li>
 
 </ul>


### PR DESCRIPTION
…reply to a subscribed thread:

- If false (default), preserve the existing behaviour, which is to notify the member upon the first unread reply only
- If true, notify the member upon every reply